### PR TITLE
Remove unwanted tr after search result

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -133,9 +133,9 @@
             <table class="table-fixed text-sm mt-5" style="width: max-content">
                 <tbody>
                     @foreach ($docs as $index => $doc)
-                    <tr>
+                    <tr v-if="!docs[{{$index}}]['isHidden']">
                         <td>
-                            <a href="#{{$doc['methods'][0] .'-'. $doc['uri']}}" @click="highlightSidebar({{$index}})" v-if="!docs[{{$index}}]['isHidden']">
+                            <a href="#{{$doc['methods'][0] .'-'. $doc['uri']}}" @click="highlightSidebar({{$index}})">
                                 <span class="
                                     font-medium
                                     inline-flex


### PR DESCRIPTION
Hello, [kevincobain2000](https://github.com/rakutentech/laravel-request-docs/commits?author=kevincobain2000)
Remove unwanted tr (It generate extra space) after search result

![image](https://user-images.githubusercontent.com/18529326/191255075-c7e09cd4-9726-4cb6-9045-c2d400cc1f11.png)


Let me know if any changes

Thank you
Chintan